### PR TITLE
tools: add organization name and state to generated certificates

### DIFF
--- a/tools/ca.config
+++ b/tools/ca.config
@@ -4,4 +4,6 @@ prompt                 = no
 
 [ req_distinguished_name ]
 C                      = PL
+O                      = Fobnail
+ST                     = State
 CN                     = CA certificate

--- a/tools/ek.config
+++ b/tools/ek.config
@@ -4,4 +4,6 @@ prompt                 = no
 
 [ req_distinguished_name ]
 C                      = PL
+O                      = Fobnail
+ST                     = State
 CN                     = EK certificate


### PR DESCRIPTION
Workaround - Fobnail requires these fields to parse certificate.